### PR TITLE
spelling correction  and timestamp correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ device.on_command = callback_command  # Callback for received commands
 # Set the device Attributes, Data and Commands that will be sent on the DBIRTH message --------------------------
 
 # Attributes
-device.attribures.set_value("description", "Simple EoN Device node")
-device.attribures.set_value("type", "Simulated-EoND-device")
-device.attribures.set_value("version", "0.01")
+device.attributes.set_value("description", "Simple EoN Device node")
+device.attributes.set_value("type", "Simulated-EoND-device")
+device.attributes.set_value("version", "0.01")
 
 # Data / Telemetry
 device.data.set_value("value", 0)
@@ -140,7 +140,7 @@ app.on_command = callback_app_command
 # Set the device Attributes, Data and Commands that will be sent on the DBIRTH message --------------------------
 
 # Attributes
-app.attribures.set_value("description", "Test application")
+app.attributes.set_value("description", "Test application")
 
 # Commands
 app.commands.set_value("rebirth", False)

--- a/examples/example_basic_eond.py
+++ b/examples/example_basic_eond.py
@@ -27,9 +27,9 @@ device.on_command = callback_command  # Callback for received commands
 # Set the device Attributes, Data and Commands that will be sent on the DBIRTH message --------------------------
 
 # Attributes
-device.attribures.set_value("description", "Simple EoN Device node")
-device.attribures.set_value("type", "Simulated-EoND-device")
-device.attribures.set_value("version", "0.01")
+device.attributes.set_value("description", "Simple EoN Device node")
+device.attributes.set_value("type", "Simulated-EoND-device")
+device.attributes.set_value("version", "0.01")
 
 # Data / Telemetry
 device.data.set_value("value", 0)

--- a/examples/example_basic_listener.py
+++ b/examples/example_basic_listener.py
@@ -23,7 +23,7 @@ app.on_command = callback_app_command
 # Set the device Attributes, Data and Commands that will be sent on the DBIRTH message --------------------------
 
 # Attributes
-app.attribures.set_value("description", "Test application")
+app.attributes.set_value("description", "Test application")
 
 # Commands
 app.commands.set_value("rebirth", False)

--- a/examples/mqtt_spb_listener.py
+++ b/examples/mqtt_spb_listener.py
@@ -45,7 +45,7 @@ def on_message(client, userdata, msg):
         except:
             pass
 
-    print(datetime.datetime.utcnow().isoformat() + " " + msg.topic + "\n\t\t" + _data)
+    print(datetime.datetime.now().isoformat() + " " + msg.topic + "\n\t\t" + _data)
 
 
 # Set up the MQTT client connection that will listen to all Sparkplug B messages

--- a/examples/spb_app_listener.py
+++ b/examples/spb_app_listener.py
@@ -74,7 +74,7 @@ app.on_message = callback_app_message
 app.on_command = callback_app_command
 
 # ATTRIBUTES
-app.attribures.set_value("Info", "Test application")
+app.attributes.set_value("Info", "Test application")
 
 # COMMANDS
 app.commands.set_value("ping", False)

--- a/examples/spb_discovery.py
+++ b/examples/spb_discovery.py
@@ -169,7 +169,7 @@ for group_name in spb_groups.keys():
 
             # Print entity Attributes, commands, data
             print("  %s %s %s ATTR/" % (L1, L2, TEE))
-            attributes = entity.attribures.get_dictionary()
+            attributes = entity.attributes.get_dictionary()
             if len(attributes) != 0:
                 for field in attributes:
                     _value = field['value']

--- a/examples/spb_eond_csv_player.py
+++ b/examples/spb_eond_csv_player.py
@@ -85,7 +85,7 @@ for k in config['data']['commands']:
 print("--- ATTRIBUTES")
 for k in attributes:
     print("  %s - %s"%(k, str(attributes[k])))
-    device.attribures.set_value(k, attributes[k])
+    device.attributes.set_value(k, attributes[k])
 
 print("--- COMMANDS")
 for k in commands:

--- a/examples/spb_eond_simple.py
+++ b/examples/spb_eond_simple.py
@@ -90,7 +90,7 @@ telemetry = {"value": 0,    # Simple value counter
 print("--- ATTRIBUTES")
 for k in attributes:
     print("  %s - %s"%(k, str(attributes[k])))
-    device.attribures.set_value(k, attributes[k])
+    device.attributes.set_value(k, attributes[k])
 
 print("--- COMMANDS")
 for k in commands:

--- a/examples/spb_scada_send_cmd.py
+++ b/examples/spb_scada_send_cmd.py
@@ -38,7 +38,7 @@ scada = MqttSpbEntityScada(spb_group_name= _config_spb_group_name,
                            debug_info=_DEBUG)
 
 # ATTRIBUTES
-scada.attribures.set_value("description", "SCADA application simple")
+scada.attributes.set_value("description", "SCADA application simple")
 
 # Connect to the broker.
 _connected = False

--- a/examples/spb_scada_simple.py
+++ b/examples/spb_scada_simple.py
@@ -79,7 +79,7 @@ def callback_scada_message(topic : MqttSpbTopic, payload):
 
                 # Update entity field value
                 if _type == "ATTR":
-                    entity.attribures.set_value(_name, _value)
+                    entity.attributes.set_value(_name, _value)
                 elif _type == "DATA":
                     entity.data.set_value(_name, _value)
                 elif _type == "CMD":
@@ -111,7 +111,7 @@ scada = MqttSpbEntityScada(spb_group_name= _config_spb_group_name,
 scada.on_message = callback_scada_message
 
 # ATTRIBUTES
-scada.attribures.set_value("description", "SCADA application simple")
+scada.attributes.set_value("description", "SCADA application simple")
 
 # Connect to the broker.
 _connected = False

--- a/src/mqtt_spb_wrapper/mqtt_spb_wrapper.py
+++ b/src/mqtt_spb_wrapper/mqtt_spb_wrapper.py
@@ -160,7 +160,7 @@ class MqttSpbEntity:
         self.is_alive = True
         self.is_birth_published = False
 
-        self.attribures = self._ValuesGroup()
+        self.attributes = self._ValuesGroup()
         self.data = self._ValuesGroup()
         self.commands = self._ValuesGroup()
 
@@ -207,12 +207,12 @@ class MqttSpbEntity:
         if self._spb_eon_device_name is not None:
             temp['spb_eon_device_name'] = self._spb_eon_device_name
         temp['data'] = self.data.get_dictionary()
-        temp['attributes'] = self.attribures.get_dictionary()
+        temp['attributes'] = self.attributes.get_dictionary()
         temp['commands'] = self.commands.get_dictionary()
         return temp
 
     def is_empty(self):
-        if self.data.is_empty() and self.attribures.is_empty() and self.commands.is_empty():
+        if self.data.is_empty() and self.attributes.is_empty() and self.commands.is_empty():
             return True
         return False
 
@@ -262,8 +262,8 @@ class MqttSpbEntity:
             payload = getDeviceBirthPayload()
 
         # Attributes
-        if not self.attribures.is_empty():
-            for item in self.attribures.values:
+        if not self.attributes.is_empty():
+            for item in self.attributes.values:
                 name = "ATTR/" + item.name
                 addMetric(payload, name, None, self._spb_data_type(item.value), item.value, item.timestamp)
 
@@ -294,7 +294,7 @@ class MqttSpbEntity:
 
                 if field['name'].startswith("ATTR/"):
                     field['name'] = field['name'][5:]
-                    self.attribures.set_value(field['name'], field['value'], field['timestamp'])  # update field
+                    self.attributes.set_value(field['name'], field['value'], field['timestamp'])  # update field
 
                 elif field['name'].startswith("CMD/"):
                     field['name'] = field['name'][4:]

--- a/src/mqtt_spb_wrapper/mqtt_spb_wrapper.py
+++ b/src/mqtt_spb_wrapper/mqtt_spb_wrapper.py
@@ -533,7 +533,7 @@ class MqttSpbEntity:
         if self._loopback_topic == msg.topic:
                 return
 
-        msg_ts_rx = int(round(datetime.datetime.now().utcnow().time() * 1000))  # Save the current timestamp
+        msg_ts_rx = int(round(datetime.datetime.now().now().time() * 1000))  # Save the current timestamp
 
         logger.info("%s - Message received  %s" % (self._entity_domain, msg.topic))
 
@@ -612,7 +612,7 @@ class MqttSpbEntity:
             self.name = name
             self._value = value
             if timestamp is None:
-                self._timestamp = int(datetime.datetime.now().utcnow().time() * 1000)
+                self._timestamp = int(datetime.datetime.now().now().time() * 1000)
             else:
                 self._timestamp = timestamp
             self.is_updated = True
@@ -654,7 +654,7 @@ class MqttSpbEntity:
                 self._timestamp = int(value)
 
         def timestamp_update(self):
-            self.timestamp = int(datetime.datetime.utcnow().timestamp() * 1000)
+            self.timestamp = int(datetime.datetime.now().timestamp() * 1000)
 
     class _ValuesGroup:
 


### PR DESCRIPTION
there was a spelling mistake in attributes which was corrected.

datetime.utcnow().timestamp() does not give the correct timestamp it should be datetime.now().timestamp().